### PR TITLE
Escape commas and backslashes. fixes #42

### DIFF
--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -237,8 +237,8 @@ export class Formatter {
   private e(s: string | undefined): string {
     if (!s) return "";
     const escapedBackslashes = s.split("\\").join("\\\\");
-    const escapedCommas = escapedBackslashes.split(",").join(",");
-    const escapedSemicolons = escapedCommas.split(";").join(";");
+    const escapedCommas = escapedBackslashes.split(",").join("\\,");
+    const escapedSemicolons = escapedCommas.split(";").join("\\;");
     const escapedNewlines = escapedSemicolons.split("\n").join("\\n");
     return escapedNewlines;
   }


### PR DESCRIPTION
I think this is the correct fix, but I'm not certain. I am using this already locally, and it seems to work, although it generated what I found to be unexpected behaviour in `addPhoto()`. However, I suspect that the behaviour I saw is probably correct.

I'm adding photos with a string like `data:${mediaType},${photoBase64}` and I suspect that this comma is actually supposed to be escaped, because it is not  separator inside the photo field. There aren't 2 photos, there's just 1, and part of that photo's data is a comma.

Anyway, merge at your own risk, that's what I'm saying!