### PR TITLE
2.1.0: accept null/undefined in addAddress (fixes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `2.1.0`
+
+- `addAddress` now accepts `null` or `undefined` for any of the five component fields, normalizing them to empty strings internally. Matches the README wording. Closes #30.
+
 ## `2.0.0`
 
 - **Breaking**: RFC6350 §3.4 value escaping is now correct. Commas (`,`) and semicolons (`;`) inside property text values are now escaped to `\,` and `\;` (previously emitted unescaped). Output for any vcard with `,` or `;` in a value will differ.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covve/easy-vcard",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Simple vcard formatter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/vcard/vcard.spec.ts
+++ b/src/vcard/vcard.spec.ts
@@ -242,6 +242,21 @@ describe('VCard', () => {
       const addresses = sut.toJSON().addresses ?? [];
       expect(addresses.length).toEqual(1);
     });
+
+    it('normalizes null and undefined address fields to empty strings', () => {
+      const sut = new VCard();
+      sut.addAddress('123 Main', null, undefined, null, 'USA', { type: 'home' });
+      const addresses = sut.toJSON().addresses ?? [];
+      expect(addresses.length).toEqual(1);
+      expect(addresses[0]).toEqual({
+        street: '123 Main',
+        locality: '',
+        region: '',
+        postCode: '',
+        country: 'USA',
+        params: { type: 'home' },
+      });
+    });
   });
 
   describe('isolation', () => {

--- a/src/vcard/vcard.ts
+++ b/src/vcard/vcard.ts
@@ -173,15 +173,22 @@ export class VCard {
   }
 
   public addAddress(
-    street: string,
-    locality: string,
-    region: string,
-    postCode: string,
-    country: string,
+    street: string | null | undefined,
+    locality: string | null | undefined,
+    region: string | null | undefined,
+    postCode: string | null | undefined,
+    country: string | null | undefined,
     params?: IParams
   ): this {
     this._addresses = this._addresses || [];
-    this._addresses.push({ street, locality, region, postCode, country, params });
+    this._addresses.push({
+      street: street ?? "",
+      locality: locality ?? "",
+      region: region ?? "",
+      postCode: postCode ?? "",
+      country: country ?? "",
+      params,
+    });
     return this;
   }
 


### PR DESCRIPTION
## Summary

Loosens `addAddress` to accept `string | null | undefined` for each of the five component fields (street, locality, region, postCode, country), normalizing each to `''` inside the method. This aligns the type signature with the README wording ("Fields not available should be null or undefined").

Backwards compatible: any caller passing strings — including empty strings — continues to work unchanged. The internal `IAddress` shape (which formatters and consumers read via `toJSON()`) is also unchanged.

Closes #30.

## Test plan

- [x] `npm test` — 88/88 passing (1 new test: normalizes null and undefined address fields to empty strings)
- [x] `npm run lint` clean
- [x] `npm run build` clean