### PR TITLE
ci: auto-publish to npm on semver tag push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,12 @@ defaults: &defaults
   docker:
     - image: cimg/node:22.14
 
-version: 2
+version: 2.1
+
 jobs:
   build:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/easy-vcard
       - checkout
       - run:
           name: install node modules
@@ -18,8 +17,48 @@ jobs:
       - run:
           name: test easy-vcard
           command: npm run test:ci
-      - store_test_results:
-          path: ~/xapp/test_results
+      - run:
+          name: lint easy-vcard
+          command: npm run lint
       - run:
           name: build easy-vcard
           command: npm run build
+
+  publish:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: verify tag matches package.json version
+          command: |
+            PKG_VERSION="v$(node -p "require('./package.json').version")"
+            if [ "$CIRCLE_TAG" != "$PKG_VERSION" ]; then
+              echo "Tag $CIRCLE_TAG does not match package.json version $PKG_VERSION"
+              exit 1
+            fi
+      - run:
+          name: install (runs prepare -> tsc build via npm lifecycle)
+          command: npm install --unsafe-perm=true --no-save
+      - run:
+          name: authenticate with npm
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
+          name: publish to npm (runs prepublishOnly -> test + lint via npm lifecycle)
+          command: npm publish --access public
+
+workflows:
+  version: 2
+  build_and_publish:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+      - publish:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ Parsing existing vCard strings is out of scope for this library. For parsing, se
 
 PRs and issues welcome. See `CHANGELOG.md` for the version history.
 
+### Releasing
+
+Releases are automated. To cut a new version:
+
+1. Bump `version` in `package.json` and add a `CHANGELOG.md` entry in a PR. Merge.
+2. Tag the merge commit with `vX.Y.Z` matching the new `package.json` version and push the tag:
+   ```
+   git tag v2.3.0 && git push origin v2.3.0
+   ```
+3. CircleCI's `publish` job runs on tag push: it installs, builds, lints, tests, and runs `npm publish --access public` using the `NPM_TOKEN` configured in the CircleCI project. A guard step fails the publish if the tag name doesn't match `package.json.version`.
+
+Pre-release tags (e.g. `v2.3.0-beta.1`) are not published automatically — only strict-semver tags (`vMAJOR.MINOR.PATCH`).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a CircleCI workflow that automatically publishes to npm when a strict-semver tag is pushed. Eliminates the need for maintainers to run `npm publish --otp=…` from a laptop.

## How it works

- **Branch push** (incl. PRs): the existing `build` job runs — install, test, lint, build. No publish.
- **Tag push matching `vX.Y.Z`**: `build` runs first, then `publish` runs.
- **Tag push matching anything else** (e.g. `v2.3.0-beta.1`, `release-2.3`): only `build` runs. Pre-release / non-semver tags don't auto-publish.

The `publish` job:
1. Verifies that `package.json.version` matches the pushed tag (fails fast on mismatch — prevents accidental wrong-version publishes).
2. `npm install` (which triggers `prepare` → `tsc -p tsconfig.build.json` via npm lifecycle).
3. Writes `~/.npmrc` with `NPM_TOKEN` for registry auth.
4. `npm publish --access public` (which triggers `prepublishOnly` → `npm test && npm run lint` via npm lifecycle).

## Required configuration (one-time, before first release)

In **CircleCI → Project Settings → Environment Variables**, add:

| Name | Value |
|---|---|
| `NPM_TOKEN` | An npm **automation token** generated from npmjs.com (Account → Access Tokens → Automation). Automation tokens bypass 2FA OTP and are designed for CI use. |

## Releasing after this lands

1. Bump `version` in `package.json`, update `CHANGELOG.md`, open a PR, merge.
2. `git tag v2.3.0 && git push origin v2.3.0` from the merge commit.
3. CircleCI takes it from there.

The release flow is also documented in the README under **Contributing → Releasing**.

## Test plan

- [x] `circleci config validate` passes locally
- [ ] After merge + first tag push: confirm CircleCI runs both `build` and `publish` jobs, and the package lands on npm